### PR TITLE
[DO NOT MERGE][ASIAGO #149515967] Server Side Rendering

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -48,6 +48,14 @@ function getServedPath(appPackageJson) {
   return ensureSlash(servedUrl, true);
 }
 
+// use realpathSync to resolve symbolic links in path, when asiago is installed using `npm link asiago`
+const asiagoLocation = fs.existsSync(resolveApp('node_modules/@brickwork-software/asiago'))
+  ? resolveApp('node_modules/@brickwork-software/asiago')
+  : resolveApp('..');
+const asiagoDirectory = fs.realpathSync(asiagoLocation)
+
+const resolveOwn = relativePath => path.resolve(__dirname, '..', relativePath);
+
 // config after eject: we're in ./config/
 module.exports = {
   dotenv: resolveApp('.env'),
@@ -55,66 +63,71 @@ module.exports = {
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),
   appIndexJs: resolveApp('src/index.js'),
+  asiago: asiagoDirectory,
+  libraryIndexJs: resolveApp('src/handler.js'),
   appPackageJson: resolveApp('package.json'),
-  appSrc: resolveApp('src'),
+  app: appDirectory,
+  appSrc: path.resolve(appDirectory, 'src'),
   yarnLockFile: resolveApp('yarn.lock'),
   testsSetup: resolveApp('src/setupTests.js'),
   appNodeModules: resolveApp('node_modules'),
+  ownNodeModules: resolveOwn('../node_modules'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
 };
 
-// @remove-on-eject-begin
-const resolveOwn = relativePath => path.resolve(__dirname, '..', relativePath);
-
-// config before eject: we're in ./node_modules/react-scripts/config/
-module.exports = {
-  dotenv: resolveApp('.env'),
-  appPath: resolveApp('.'),
-  appBuild: resolveApp('build'),
-  appPublic: resolveApp('public'),
-  appHtml: resolveApp('public/index.html'),
-  appIndexJs: resolveApp('src/index.js'),
-  appPackageJson: resolveApp('package.json'),
-  appSrc: resolveApp('src'),
-  yarnLockFile: resolveApp('yarn.lock'),
-  testsSetup: resolveApp('src/setupTests.js'),
-  appNodeModules: resolveApp('node_modules'),
-  publicUrl: getPublicUrl(resolveApp('package.json')),
-  servedPath: getServedPath(resolveApp('package.json')),
-  // These properties only exist before ejecting:
-  ownPath: resolveOwn('.'),
-  ownNodeModules: resolveOwn('node_modules'), // This is empty on npm 3
-};
-
-const ownPackageJson = require('../package.json');
-const reactScriptsPath = resolveApp(`node_modules/${ownPackageJson.name}`);
-const reactScriptsLinked =
-  fs.existsSync(reactScriptsPath) &&
-  fs.lstatSync(reactScriptsPath).isSymbolicLink();
-
-// config before publish: we're in ./packages/react-scripts/config/
-if (
-  !reactScriptsLinked &&
-  __dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1
-) {
-  module.exports = {
-    dotenv: resolveOwn('template/.env'),
-    appPath: resolveApp('.'),
-    appBuild: resolveOwn('../../build'),
-    appPublic: resolveOwn('template/public'),
-    appHtml: resolveOwn('template/public/index.html'),
-    appIndexJs: resolveOwn('template/src/index.js'),
-    appPackageJson: resolveOwn('package.json'),
-    appSrc: resolveOwn('template/src'),
-    yarnLockFile: resolveOwn('template/yarn.lock'),
-    testsSetup: resolveOwn('template/src/setupTests.js'),
-    appNodeModules: resolveOwn('node_modules'),
-    publicUrl: getPublicUrl(resolveOwn('package.json')),
-    servedPath: getServedPath(resolveOwn('package.json')),
-    // These properties only exist before ejecting:
-    ownPath: resolveOwn('.'),
-    ownNodeModules: resolveOwn('node_modules'),
-  };
-}
-// @remove-on-eject-end
+// // @remove-on-eject-begin
+// const resolveOwn = relativePath => path.resolve(__dirname, '..', relativePath);
+//
+// // config before eject: we're in ./node_modules/react-scripts/config/
+// module.exports = {
+//   dotenv: resolveApp('.env'),
+//   appPath: resolveApp('.'),
+//   appBuild: resolveApp('build'),
+//   appPublic: resolveApp('public'),
+//   appHtml: resolveApp('public/index.html'),
+//   appIndexJs: resolveApp('src/index.js'),
+//   libraryIndexJs: resolveApp('src/handler.js'),
+//   appPackageJson: resolveApp('package.json'),
+//   app: resolveApp('src'),
+//   yarnLockFile: resolveApp('yarn.lock'),
+//   testsSetup: resolveApp('src/setupTests.js'),
+//   appNodeModules: resolveApp('node_modules'),
+//   publicUrl: getPublicUrl(resolveApp('package.json')),
+//   servedPath: getServedPath(resolveApp('package.json')),
+//   // These properties only exist before ejecting:
+//   ownPath: resolveOwn('.'),
+//   ownNodeModules: resolveOwn('node_modules'), // This is empty on npm 3
+// };
+//
+// const ownPackageJson = require('../package.json');
+// const reactScriptsPath = resolveApp(`node_modules/${ownPackageJson.name}`);
+// const reactScriptsLinked =
+//   fs.existsSync(reactScriptsPath) &&
+//   fs.lstatSync(reactScriptsPath).isSymbolicLink();
+//
+// // config before publish: we're in ./packages/react-scripts/config/
+// if (
+//   !reactScriptsLinked &&
+//   __dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1
+// ) {
+//   module.exports = {
+//     dotenv: resolveOwn('template/.env'),
+//     appPath: resolveApp('.'),
+//     appBuild: resolveOwn('../../build'),
+//     appPublic: resolveOwn('template/public'),
+//     appHtml: resolveOwn('template/public/index.html'),
+//     appIndexJs: resolveOwn('template/src/index.js'),
+//     appPackageJson: resolveOwn('package.json'),
+//     app: resolveOwn('template/src'),
+//     yarnLockFile: resolveOwn('template/yarn.lock'),
+//     testsSetup: resolveOwn('template/src/setupTests.js'),
+//     appNodeModules: resolveOwn('node_modules'),
+//     publicUrl: getPublicUrl(resolveOwn('package.json')),
+//     servedPath: getServedPath(resolveOwn('package.json')),
+//     // These properties only exist before ejecting:
+//     ownPath: resolveOwn('.'),
+//     ownNodeModules: resolveOwn('node_modules'),
+//   };
+// }
+// // @remove-on-eject-end

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -112,7 +112,12 @@ module.exports = {
     // We placed these paths second because we want `node_modules` to "win"
     // if there are any conflicts. This matches Node resolution mechanism.
     // https://github.com/facebookincubator/create-react-app/issues/253
-    modules: ['node_modules', paths.appNodeModules].concat(
+    modules: [
+      paths.app,
+      // paths.appNodeModules,
+      path.resolve(paths.asiago),
+      'node_modules',
+    ].concat(
       // It is guaranteed to exist because we tweak it in `env.js`
       process.env.NODE_PATH.split(path.delimiter).filter(Boolean)
     ),
@@ -130,7 +135,6 @@ module.exports = {
       // unfortunate to rely on, as react-scripts could be symlinked,
       // and thus babel-runtime might not be resolvable from the source.
       '~': paths.appNodeModules,
-      'src': paths.appSrc,
       'babel-runtime': path.dirname(
         require.resolve('babel-runtime/package.json')
       ),
@@ -145,7 +149,7 @@ module.exports = {
       // To fix this, we prevent you from importing files out of src/ -- if you'd like to,
       // please link the files into your node_modules/ and let module-resolution kick in.
       // Make sure your source files are compiled, as they will not be processed in any way.
-      new ModuleScopePlugin(paths.appSrc),
+      new ModuleScopePlugin(paths.app),
     ],
   },
   module: {
@@ -180,7 +184,7 @@ module.exports = {
             loader: require.resolve('eslint-loader'),
           },
         ],
-        include: paths.appSrc,
+        include: paths.app,
       },
       {
         // "oneOf" will traverse all following loaders until one will
@@ -202,7 +206,8 @@ module.exports = {
           {
             test: /\.(js|jsx)$/,
             include: [
-              paths.appSrc,
+              paths.app,
+              path.resolve(paths.asiago),
             ],
             loader: require.resolve('babel-loader'),
             options: {
@@ -210,11 +215,6 @@ module.exports = {
               babelrc: false,
               presets: [require.resolve('babel-preset-react-app')],
               plugins: [
-                // [require.resolve('babel-plugin-react-intl'), {
-                //   messagesDir: './build/messages/',
-                //   // enforceDescriptions: true,
-                //   extractSourceLocation: true,
-                // }],
                 'transform-function-bind',
                 ['transform-decorators-legacy']
               ],

--- a/packages/react-scripts/config/webpack.config.library.js
+++ b/packages/react-scripts/config/webpack.config.library.js
@@ -23,6 +23,7 @@ const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const paths = require('./paths');
 const getClientEnvironment = require('./env');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const nodeExternals = require('webpack-node-externals');
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
@@ -56,7 +57,7 @@ const extractTextPluginOptions = shouldUseRelativeAssetPaths
   : {};
 
 // Define what the compiled file is called (normally 'brickwork' but docs project overwrites it)
-const mainEntry = process.env['MAIN_ENTRY'] || 'brickwork';
+const mainEntry = 'universal';
 
 // This is the production configuration.
 // It compiles slowly and is focused on producing a fast and minimal bundle.
@@ -64,12 +65,14 @@ const mainEntry = process.env['MAIN_ENTRY'] || 'brickwork';
 module.exports = {
   // Don't attempt to continue if there are any errors.
   bail: true,
+  target: 'node',
+  externals: [nodeExternals()],
   // We generate sourcemaps in production. This is slow but gives good results.
   // You can exclude the *.map files from the build during deployment.
   devtool: 'source-map',
   // In production, we only want to load the polyfills and the app code.
   entry: {
-    [mainEntry]: [require.resolve('./polyfills'), paths.appIndexJs]
+    [mainEntry]: [require.resolve('./polyfills'), paths.libraryIndexJs]
   },
   output: {
     // The build folder.
@@ -85,7 +88,7 @@ module.exports = {
     // Point sourcemap entries to original disk location (format as URL on Windows)
     devtoolModuleFilenameTemplate: info =>
       path
-        .relative(paths.appSrc, info.absoluteResourcePath)
+        .relative(paths.app, info.absoluteResourcePath)
         .replace(/\\/g, '/'),
   },
   resolve: {
@@ -110,7 +113,7 @@ module.exports = {
       // It usually still works on npm 3 without this but it would be
       // unfortunate to rely on, as react-scripts could be symlinked,
       // and thus babel-runtime might not be resolvable from the source.
-      'src': paths.appSrc,
+      'src': paths.app,
       'babel-runtime': path.dirname(
         require.resolve('babel-runtime/package.json')
       ),
@@ -125,7 +128,7 @@ module.exports = {
       // To fix this, we prevent you from importing files out of src/ -- if you'd like to,
       // please link the files into your node_modules/ and let module-resolution kick in.
       // Make sure your source files are compiled, as they will not be processed in any way.
-      new ModuleScopePlugin(paths.appSrc),
+      new ModuleScopePlugin(paths.app),
     ],
   },
   module: {
@@ -162,7 +165,7 @@ module.exports = {
             loader: require.resolve('eslint-loader'),
           },
         ],
-        include: paths.appSrc,
+        include: paths.app,
       },
       {
         // "oneOf" will traverse all following loaders until one will
@@ -182,7 +185,7 @@ module.exports = {
           // Process JS with Babel.
           {
             test: /\.(js|jsx)$/,
-            include: paths.appSrc,
+            include: paths.app,
             loader: require.resolve('babel-loader'),
             options: {
               // @remove-on-eject-begin

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -85,7 +85,7 @@ module.exports = {
     // Point sourcemap entries to original disk location (format as URL on Windows)
     devtoolModuleFilenameTemplate: info =>
       path
-        .relative(paths.appSrc, info.absoluteResourcePath)
+        .relative(paths.app, info.absoluteResourcePath)
         .replace(/\\/g, '/'),
   },
   resolve: {
@@ -93,7 +93,12 @@ module.exports = {
     // We placed these paths second because we want `node_modules` to "win"
     // if there are any conflicts. This matches Node resolution mechanism.
     // https://github.com/facebookincubator/create-react-app/issues/253
-    modules: ['node_modules', paths.appNodeModules].concat(
+    modules: [
+      paths.app,
+      // paths.appNodeModules,
+      path.resolve(paths.asiago),
+      'node_modules',
+    ].concat(
       // It is guaranteed to exist because we tweak it in `env.js`
       process.env.NODE_PATH.split(path.delimiter).filter(Boolean)
     ),
@@ -110,7 +115,6 @@ module.exports = {
       // It usually still works on npm 3 without this but it would be
       // unfortunate to rely on, as react-scripts could be symlinked,
       // and thus babel-runtime might not be resolvable from the source.
-      'src': paths.appSrc,
       'babel-runtime': path.dirname(
         require.resolve('babel-runtime/package.json')
       ),
@@ -125,7 +129,7 @@ module.exports = {
       // To fix this, we prevent you from importing files out of src/ -- if you'd like to,
       // please link the files into your node_modules/ and let module-resolution kick in.
       // Make sure your source files are compiled, as they will not be processed in any way.
-      new ModuleScopePlugin(paths.appSrc),
+      new ModuleScopePlugin(paths.app),
     ],
   },
   module: {
@@ -162,7 +166,7 @@ module.exports = {
             loader: require.resolve('eslint-loader'),
           },
         ],
-        include: paths.appSrc,
+        include: paths.app,
       },
       {
         // "oneOf" will traverse all following loaders until one will
@@ -182,7 +186,10 @@ module.exports = {
           // Process JS with Babel.
           {
             test: /\.(js|jsx)$/,
-            include: paths.appSrc,
+            include: [
+              paths.app,
+              path.resolve(paths.asiago),
+            ],
             loader: require.resolve('babel-loader'),
             options: {
               // @remove-on-eject-begin
@@ -191,11 +198,6 @@ module.exports = {
               // @remove-on-eject-end
               compact: true,
               plugins: [
-                // [require.resolve('babel-plugin-react-intl'), {
-                //   messagesDir: './build/messages/',
-                //   // enforceDescriptions: true,
-                //   extractSourceLocation: true,
-                // }],
                 'transform-function-bind',
                 ['transform-decorators-legacy']
               ],

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -21,6 +21,7 @@
     "react-scripts": "./bin/react-scripts.js"
   },
   "dependencies": {
+    "ansi-styles": "^3.2.0",
     "autoprefixer": "7.1.1",
     "babel-core": "6.25.0",
     "babel-eslint": "7.2.3",
@@ -28,6 +29,7 @@
     "babel-loader": "7.0.0",
     "babel-plugin-css-modules-transform": "^1.2.7",
     "babel-plugin-module-resolver": "^2.7.1",
+    "babel-plugin-react-intl": "^2.3.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-function-bind": "^6.22.0",
     "babel-preset-react-app": "^3.0.0",

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -43,7 +43,7 @@ argv.push(
   JSON.stringify(
     createJestConfig(
       relativePath => path.resolve(__dirname, '..', relativePath),
-      path.resolve(paths.appSrc, '..'),
+      path.resolve(paths.app, '..'),
       false
     )
   )

--- a/packages/react-scripts/yarn.lock
+++ b/packages/react-scripts/yarn.lock
@@ -138,7 +138,7 @@ ansi-styles@^3.0.0:
   dependencies:
     color-convert "^1.0.0"
 
-ansi-styles@^3.1.0:
+ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -580,6 +580,14 @@ babel-plugin-module-resolver@^2.7.1:
     find-babel-config "^1.0.1"
     glob "^7.1.1"
     resolve "^1.2.0"
+
+babel-plugin-react-intl@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-intl/-/babel-plugin-react-intl-2.3.1.tgz#3d43912e824da005e08e8e8239d5ba784374bb00"
+  dependencies:
+    babel-runtime "^6.2.0"
+    intl-messageformat-parser "^1.2.0"
+    mkdirp "^0.5.1"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -3058,6 +3066,10 @@ inquirer@^3.0.6:
 interpret@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
+
+intl-messageformat-parser@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.3.0.tgz#c5d26ffb894c7d9c2b9fa444c67f417ab2594268"
 
 invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
These commits were all part of the server side rendering effort...

a) These react scripts are also being used to build admin... we probably should create a separate build file, webpack config for it. I'm of the mind now that it is naive to believe that the same build script could be/should be used for both (asiago and admin).
b) The `library` build is if we want to compile asiago and the `universalHandler` function down to a library... Perhaps it should be determined if that would make it run faster?