### PR TITLE
[NG-235] remove noParse moment.js

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -53,7 +53,7 @@ const postCSSLoaderOptions = {
       flexbox: 'no-2009',
     }),
   ],
-}
+};
 
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
@@ -68,7 +68,7 @@ module.exports = {
   entry: {
     [mainEntry]: [
       // We ship a few polyfills by default:
-      require.resolve('./polyfills'),// Include an alternative client for WebpackDevServer. A client's job is to
+      require.resolve('./polyfills'), // Include an alternative client for WebpackDevServer. A client's job is to
       // connect to WebpackDevServer by a socket and get notified about changes.
       // When you save a file, the client will either apply hot updates (in case
       // of CSS changes), or refresh the page (in case of JS changes). When you
@@ -84,7 +84,7 @@ module.exports = {
       // We include the app code last so that if there is a runtime error during
       // initialization, it doesn't blow up the WebpackDevServer client, and
       // changing JS code would still trigger a refresh.
-    ]
+    ],
   },
   output: {
     // Next line is not used in dev but WebpackDevServer crashes without it:
@@ -137,7 +137,7 @@ module.exports = {
         require.resolve('babel-runtime/package.json')
       ),
       // 'mapbox-gl$': path.resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js'),
-      'webworkify': 'webworkify-webpack-dropin',
+      webworkify: 'webworkify-webpack-dropin',
       // @remove-on-eject-end
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
@@ -153,9 +153,6 @@ module.exports = {
     ],
   },
   module: {
-    noParse: [
-      /moment\.js/
-    ],
     strictExportPresence: true,
     rules: [
       // TODO: Disable require.ensure as it's not a standard language feature.
@@ -205,10 +202,7 @@ module.exports = {
           {
             test: /\.(js|jsx)$/,
             exclude: /node_modules\/(?!@brickwork-software\/asiago|dot-prop)/,
-            include: [
-              paths.appPath,
-              paths.asiagoPath,
-            ],
+            include: [paths.appPath, paths.asiagoPath],
             loader: require.resolve('babel-loader'),
             options: {
               // @remove-on-eject-begin
@@ -216,7 +210,7 @@ module.exports = {
               presets: [require.resolve('babel-preset-react-app')],
               plugins: [
                 'transform-function-bind',
-                ['transform-decorators-legacy']
+                ['transform-decorators-legacy'],
               ],
               // @remove-on-eject-end
               // This is a feature of `babel-loader` for webpack (not Babel itself).
@@ -229,12 +223,12 @@ module.exports = {
             test: /\.ya?ml$/,
             use: [
               {
-                loader: 'json-loader'
+                loader: 'json-loader',
               },
               {
-                loader: 'yaml-loader'
-              }
-            ]
+                loader: 'yaml-loader',
+              },
+            ],
           },
           // "postcss" loader applies autoprefixer to our CSS.
           // "css" loader resolves paths in CSS and adds assets as dependencies.
@@ -247,8 +241,8 @@ module.exports = {
               {
                 loader: require.resolve('style-loader'),
                 options: {
-                  insertAt: 'top'
-                }
+                  insertAt: 'top',
+                },
               },
               {
                 loader: require.resolve('css-loader'),
@@ -272,8 +266,8 @@ module.exports = {
               {
                 loader: require.resolve('style-loader'),
                 options: {
-                  insertAt: 'top'
-                }
+                  insertAt: 'top',
+                },
               },
               {
                 loader: require.resolve('css-loader'),

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -22,7 +22,8 @@ const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const paths = require('./paths');
 const getClientEnvironment = require('./env');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
+  .BundleAnalyzerPlugin;
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
@@ -62,14 +63,17 @@ const mainEntry = process.env['MAIN_ENTRY'] || 'brickwork';
 
 const babelPlugins = [
   'transform-function-bind',
-  ['transform-decorators-legacy']
-]
+  ['transform-decorators-legacy'],
+];
 if (require(paths.appPackageJson).name === '@brickwork-software/asiago') {
-  babelPlugins.unshift([require.resolve('babel-plugin-react-intl'), {
-    messagesDir: 'dist/messages/',
-    // enforceDescriptions: true,
-    // extractSourceLocation: true,
-  }])
+  babelPlugins.unshift([
+    require.resolve('babel-plugin-react-intl'),
+    {
+      messagesDir: 'dist/messages/',
+      // enforceDescriptions: true,
+      // extractSourceLocation: true,
+    },
+  ]);
 }
 
 // This is the production configuration.
@@ -83,7 +87,7 @@ module.exports = {
   devtool: shouldUseSourceMap ? 'source-map' : false,
   // In production, we only want to load the polyfills and the app code.
   entry: {
-    [mainEntry]: [require.resolve('./polyfills'), paths.appIndexJs]
+    [mainEntry]: [require.resolve('./polyfills'), paths.appIndexJs],
   },
   output: {
     // The build folder.
@@ -149,9 +153,6 @@ module.exports = {
     ],
   },
   module: {
-    noParse: [
-      /moment\.js/
-    ],
     strictExportPresence: true,
     rules: [
       // TODO: Disable require.ensure as it's not a standard language feature.
@@ -202,10 +203,7 @@ module.exports = {
           {
             test: /\.(js|jsx)$/,
             exclude: /node_modules\/(?!@brickwork-software\/asiago|dot-prop)/,
-            include: [
-              paths.appPath,
-              paths.asiagoPath,
-            ],
+            include: [paths.appPath, paths.asiagoPath],
             loader: require.resolve('babel-loader'),
             options: {
               // @remove-on-eject-begin
@@ -220,12 +218,12 @@ module.exports = {
             test: /\.ya?ml$/,
             use: [
               {
-                loader: 'json-loader'
+                loader: 'json-loader',
               },
               {
-                loader: 'yaml-loader'
-              }
-            ]
+                loader: 'yaml-loader',
+              },
+            ],
           },
           // The notation here is somewhat confusing.
           // "postcss" loader applies autoprefixer to our CSS.
@@ -249,7 +247,7 @@ module.exports = {
                   insertAt: 'top',
                   // combine all <link rel="stylesheet" href="blob:..."> tags into one
                   singleton: true,
-                }
+                },
               },
               {
                 loader: require.resolve('css-loader'),
@@ -283,8 +281,8 @@ module.exports = {
               {
                 loader: require.resolve('sass-loader'),
                 options: {
-                  sourceMap: true
-                }
+                  sourceMap: true,
+                },
               },
             ],
           },
@@ -299,7 +297,7 @@ module.exports = {
                   insertAt: 'top',
                   // combine all <link rel="stylesheet" href="blob:..."> tags into one
                   singleton: true,
-                }
+                },
               },
               {
                 loader: require.resolve('css-loader'),
@@ -337,8 +335,8 @@ module.exports = {
               {
                 loader: require.resolve('sass-loader'),
                 options: {
-                  sourceMap: true
-                }
+                  sourceMap: true,
+                },
               },
             ],
           },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brickwork-software/react-scripts",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Configuration and scripts for Brickwork react apps",
   "repository": "brickworksoftware/create-react-app",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Having `module: { noParse: [/moment.js/], //... }` messes with React-Big-Calendar and any other packages that use momentJS internally. Following the suggestions documented here: https://github.com/intljusticemission/react-big-calendar/issues/527.

This will ideally go into version 1.3.5.  